### PR TITLE
func typo

### DIFF
--- a/js in one pic.opml
+++ b/js in one pic.opml
@@ -135,7 +135,7 @@
                         <outline text="'function'"></outline>
                     </outline>
                     <outline text="create">
-                        <outline text="var a = function(arg1, arg2){   //fun body; }"></outline>
+                        <outline text="var a = function(arg1, arg2){   //func body; }"></outline>
                         <outline text="function a(arg1, arg2){   // func body; }"></outline>
                         <outline text="(function(arg1,arg2){   //func body; })"></outline>
                     </outline>


### PR DESCRIPTION
Since other function bodies were commented as `func body` only the first one was 'fun body' so renamed it